### PR TITLE
Fix CDN address for MathJax to work via https

### DIFF
--- a/lib/redmine_latex_mathjax/hooks/view_layouts_base_html_head_hook.rb
+++ b/lib/redmine_latex_mathjax/hooks/view_layouts_base_html_head_hook.rb
@@ -15,7 +15,7 @@ module RedmineLatexMathjax
   });
           MathJax.Hub.Typeset();
           </script>" +
-            javascript_include_tag('http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML') + 
+            javascript_include_tag('https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML') +
             javascript_include_tag('https://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js')+
             '<script>
   jQuery.fn.contentChange = function(callback){


### PR DESCRIPTION
Modern browsers refuse to load http content when accessing pages via https.
Switch to https CDN for MathJax. This should fix process91/redmine_latex_mathjax/issues/6

Signed-off-by: Kai Blin kai.blin@age.mpg.de
