### PR TITLE
Changed CDN address to official one

### DIFF
--- a/lib/redmine_latex_mathjax/hooks/view_layouts_base_html_head_hook.rb
+++ b/lib/redmine_latex_mathjax/hooks/view_layouts_base_html_head_hook.rb
@@ -15,7 +15,7 @@ module RedmineLatexMathjax
   });
           MathJax.Hub.Typeset();
           </script>" +
-            javascript_include_tag('https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML') +
+            javascript_include_tag('https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML') +
             javascript_include_tag('https://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js')+
             '<script>
   jQuery.fn.contentChange = function(callback){


### PR DESCRIPTION
The other address is now defunct!  (See http://www.mathjax.org/changes-to-the-mathjax-cdn/)
