### PR TITLE
Setting change: Equations are numbered by default

### DIFF
--- a/app/views/redmine_latex_mathjax/_headers.html.erb
+++ b/app/views/redmine_latex_mathjax/_headers.html.erb
@@ -1,24 +1,28 @@
-module RedmineLatexMathjax
-  module Hooks
-    class ViewLayoutsBaseHtmlHeadHook < Redmine::Hook::ViewListener
-      def view_layouts_base_html_head(context={})
-          return "<script type=\"text/x-mathjax-config\">
+<script type="text/x-mathjax-config">
           MathJax.Hub.Config({
     extensions: ['tex2jax.js'],
     jax: ['input/TeX', 'output/HTML-CSS'],
     TeX: { equationNumbers: { autoNumber: 'AMS' } },
     tex2jax: {
-      inlineMath: [ ['$','$'] ],
+      inlineMath: [ ['$','$'], ['`','`'] ],
       displayMath: [ ['$$','$$'] ],
       processEscapes: true
     },
     'HTML-CSS': { availableFonts: ['TeX'] }
   });
-          MathJax.Hub.Typeset();
-          </script>" +
-            javascript_include_tag('https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML') +
-            javascript_include_tag('https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js')+
-            '<script>
+  MathJax.Hub.Register.StartupHook('TeX Jax Ready',function () {
+  MathJax.Hub.Insert(MathJax.InputJax.TeX.Definitions.macros,{
+    cancel: ['Extension','cancel'],
+    bcancel: ['Extension','cancel'],
+    xcancel: ['Extension','cancel'],
+    cancelto: ['Extension','cancel']
+  });
+});
+MathJax.Hub.Typeset();
+</script>
+<%= javascript_include_tag 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML' %>
+<%= javascript_include_tag 'https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js' %>
+<script>
   jQuery.fn.contentChange = function(callback){
     var elms = jQuery(this);
     elms.each(
@@ -44,14 +48,10 @@ module RedmineLatexMathjax
       }
     }
   },500);
-</script>' + 
-            "<script>
-            $.noConflict();
-            jQuery(document).ready(function($) {
-                $('#preview').contentChange(function() { try { MathJax.Hub.Typeset(); } catch(err) {}} );
-            });
-            </script>" 
-      end
-    end
-  end
-end
+</script>
+<script>
+$.noConflict();
+jQuery(document).ready(function($) {
+$('#preview').contentChange(function() { try { MathJax.Hub.Typeset(); } catch(err) {}} );
+});
+</script>

--- a/app/views/redmine_latex_mathjax/_headers.html.erb
+++ b/app/views/redmine_latex_mathjax/_headers.html.erb
@@ -4,7 +4,7 @@
     jax: ['input/TeX', 'output/HTML-CSS'],
     TeX: { equationNumbers: { autoNumber: 'AMS' } },
     tex2jax: {
-      inlineMath: [ ['$','$'], ['`','`'] ],
+      inlineMath: [ ['$','$'] ],
       displayMath: [ ['$$','$$'] ],
       processEscapes: true
     },

--- a/init.rb
+++ b/init.rb
@@ -1,4 +1,5 @@
 require 'redmine'
+require 'dispatcher' unless Rails::VERSION::MAJOR >= 3
 ::Rails.logger.info 'Redmine LaTeX MathJax'
 
 Redmine::Plugin.register :redmine_latex_mathjax do
@@ -7,7 +8,18 @@ Redmine::Plugin.register :redmine_latex_mathjax do
   description 'Employ MathJax in all settings: wiki, issues, or every page.'
   url ''
   author_url ''
-  version '0.1.0'
+  version '0.2.0'
 end
 
-require 'redmine_latex_mathjax/hooks/view_layouts_base_html_head_hook'
+# require 'redmine_latex_mathjax/hooks/view_layouts_base_html_head_hook'
+
+if Rails::VERSION::MAJOR >= 3
+  ActionDispatch::Callbacks.to_prepare do
+    require_dependency 'redmine_latex_mathjax/hooks'
+  end
+else
+  Dispatcher.to_prepare :redmine_latex_mathjax do
+    require_dependency 'redmine_latex_mathjax/hooks'
+  end
+end
+

--- a/lib/redmine_latex_mathjax/hooks.rb
+++ b/lib/redmine_latex_mathjax/hooks.rb
@@ -1,0 +1,22 @@
+#*******************************************************************************
+# redmine_latex_mathjax Redmine plugin.
+#
+# Hooks.
+#
+# Authors:
+# - ...
+#
+# Terms of use:
+# - GNU GENERAL PUBLIC LICENSE Version 2
+#*******************************************************************************
+
+module RedmineLatexMathjax
+  class Hooks  < Redmine::Hook::ViewListener
+
+    # Add stylesheets and javascripts links to all pages
+    # (there's no way to add them on specific existing page)
+    render_on :view_layouts_base_html_head,
+      :partial => "redmine_latex_mathjax/headers" 
+
+  end # class
+end # module

--- a/lib/redmine_latex_mathjax/hooks/view_layouts_base_html_head_hook.rb
+++ b/lib/redmine_latex_mathjax/hooks/view_layouts_base_html_head_hook.rb
@@ -6,6 +6,7 @@ module RedmineLatexMathjax
           MathJax.Hub.Config({
     extensions: ['tex2jax.js'],
     jax: ['input/TeX', 'output/HTML-CSS'],
+    TeX: { equationNumbers: { autoNumber: 'AMS' } },
     tex2jax: {
       inlineMath: [ ['$','$'] ],
       displayMath: [ ['$$','$$'] ],


### PR DESCRIPTION
This configuration change makes equations to be numbered by default

$$
\begin{equation}
   E = mc^2
\end{equation}
$$

About equations : http://docs.mathjax.org/en/latest/tex.html#automatic-equation-numbering